### PR TITLE
Feature/database formatter

### DIFF
--- a/Manifest/manifest - Chrome.json
+++ b/Manifest/manifest - Chrome.json
@@ -85,6 +85,7 @@
                 "library/boomiapp/connectionOperations.js",
                 "library/boomiapp/versionNotification.js",
                 "library/boomiapp/modalButtons.js",
+                "library/boomiapp/documentViewer.js",
                 "library/inject/rasterizeHTML.min.js",
                 "library/inject/showdown.min.js",
                 "library/inject/codeflask.min.js"

--- a/Manifest/manifest - FireFox.json
+++ b/Manifest/manifest - FireFox.json
@@ -81,6 +81,7 @@
                 "library/boomiapp/connectionOperations.js",
                 "library/boomiapp/versionNotification.js",
                 "library/boomiapp/modalButtons.js",
+                "library/boomiapp/documentViewer.js",
                 "library/inject/rasterizeHTML.min.js",
                 "library/inject/showdown.min.js",
                 "library/inject/codeflask.min.js"

--- a/Manifest/manifest - MS Egde.json
+++ b/Manifest/manifest - MS Egde.json
@@ -80,6 +80,7 @@
                 "library/boomiapp/customRefresh.js",
                 "library/boomiapp/menuOpen.js",
                 "library/boomiapp/connectionOperations.js",
+                "library/boomiapp/documentViewer.js",
                 "library/inject/rasterizeHTML.min.js",
                 "library/inject/showdown.min.js",
                 "library/inject/codeflask.min.js"

--- a/src/library/boomiapp/contentScript.js
+++ b/src/library/boomiapp/contentScript.js
@@ -20,6 +20,7 @@ loadScript("./library/boomiapp/customRefresh.js");
 loadScript("./library/boomiapp/connectionOperations.js");
 loadScript("./library/boomiapp/versionNotification.js");
 loadScript("./library/boomiapp/modalButtons.js");
+loadScript("./library/boomiapp/documentViewer.js");
 loadScript("./library/inject/rasterizeHTML.min.js");
 loadScript("./library/inject/showdown.min.js");
 loadScript("./library/inject/codeflask.min.js");

--- a/src/library/boomiapp/documentViewer.js
+++ b/src/library/boomiapp/documentViewer.js
@@ -1,0 +1,268 @@
+// documentViewer.js
+// -----------------
+// Inyecta un toggle en el modal de Document Viewer y, al activarlo, renderiza
+// los datos BD en una tabla; al desactivarlo, restaura el textarea original.
+
+(function(){
+  console.log('⚙️ documentViewer.js cargado');
+
+  let dbViewEnabled = false;
+  let originalRaw = null; // Store the raw text just before showing the table
+  let savedStyles = {};   // Store original textarea styles
+
+  // 1) Detecta si un raw corresponde a BD (delimitadores '|#|' y '|@|')
+  const isDbDoc = raw => raw && raw.includes('|#|') && raw.includes('|@|'); // Added null check for safety
+
+  // 2) Parsea raw y construye tabla
+  function renderDbTable(raw, container) {
+    // 1) Quita envoltorios DBSTART…DBEND
+    let body = raw;
+    if (/^DBSTART\|/.test(body)) {
+      body = body
+        .replace(/^DBSTART\|[\s\S]*?\|@?\|/, '')
+        .replace(/\|@?\|DBEND\|[\s\S]*$/, '');
+    }
+  
+    // 2) Elimina la cabecera BEGIN…OUT_START sobrante
+    //    (p. ej. "BEGIN|2|@|OUT_START|3|@|")
+    body = body.replace(/^BEGIN\|\d+\|@\|OUT_START\|\d+\|@\|/, '');
+  
+    // 3) Divide en segmentos con "|#|" y filtra vacíos/OUT_END/END
+    const segments = body
+      .split('|#|')
+      .map(s => s.trim())
+      .filter(s => s && !/^OUT_END/.test(s) && !/^END/.test(s));
+  
+    // 4) Convierte cada segmento en array de campos usando "|^|"
+    const rows = segments.map(seg => seg.split('|^|'));
+  
+    if (!rows.length) {
+      container.innerHTML = '<p style="padding:10px;color:#888;">No hay datos.</p>';
+      return;
+    }
+  
+    // 5) Calcula máximo de columnas y normaliza
+    const colCount = Math.max(...rows.map(r => r.length));
+    rows.forEach(r => { while (r.length < colCount) r.push(''); });
+  
+    // 6) Cabeceras genéricas
+    const headers = Array.from({ length: colCount }, (_, i) => `Column${i+1}`);
+  
+    // 7) Wrapper scrollable
+    container.innerHTML = '';
+    const wrap = document.createElement('div');
+    wrap.style.overflowX = 'auto';
+    wrap.style.overflowY = 'auto';
+    wrap.style.maxHeight = '300px';
+    wrap.style.maxWidth  = '100%';
+    wrap.style.border    = '1px solid #ddd';
+  
+    // 8) Construye tabla
+    const table = document.createElement('table');
+    table.style.borderCollapse = 'collapse';
+    table.style.width          = 'max-content';
+    table.style.minWidth       = '100%';
+  
+    // Cabecera
+    const thead = table.appendChild(document.createElement('thead'));
+    const htr   = thead.appendChild(document.createElement('tr'));
+    headers.forEach(h => {
+      const th = htr.appendChild(document.createElement('th'));
+      th.innerText        = h;
+      th.style.padding    = '6px';
+      th.style.border     = '1px solid #ccc';
+      th.style.background = '#f0f0f0';
+      th.style.whiteSpace = 'nowrap';
+    });
+  
+    // Cuerpo
+    const tbody = table.appendChild(document.createElement('tbody'));
+    rows.forEach((row, idx) => {
+      const tr = tbody.appendChild(document.createElement('tr'));
+      row.forEach(cell => {
+        const td = tr.appendChild(document.createElement('td'));
+        td.innerText        = cell;
+        td.style.padding    = '4px';
+        td.style.border     = '1px solid #eee';
+        td.style.whiteSpace = 'nowrap';
+      });
+      if (idx % 2) tr.style.background = '#fafafa';
+    });
+  
+    wrap.appendChild(table);
+    container.appendChild(wrap);
+  }
+  
+
+  // 3) Crea o recupera el textarea original para restaurar
+  function restoreTextarea(container) {
+    // Limpia container
+    container.innerHTML = '';
+    // Crea nuevo textarea
+    const ta = document.createElement('textarea');
+    ta.className = 'gwt-TextArea'; // Use the original class
+    // Apply saved styles (ensure they were captured)
+    ta.style.width = savedStyles.width || '100%'; // Provide defaults
+    ta.style.height = savedStyles.height || '300px'; // Provide defaults
+    ta.readOnly = true; // Match original Boomi behavior (usually read-only)
+    ta.value = originalRaw || ''; // Use the captured raw value
+    container.appendChild(ta);
+    console.log('   • textarea restaurado');
+  }
+
+  // 4) Obtiene el textarea visible y sus estilos
+  function findVisibleTextarea(modal) {
+    // Find the textarea that is currently visible (part of the DOM layout)
+    const ta = Array.from(modal.querySelectorAll('textarea.gwt-TextArea'))
+                    .find(el => el.offsetParent !== null);
+    if (ta) {
+        // Capture styles *every time* we find it, in case they change
+        savedStyles = {
+            width: ta.style.width || ta.offsetWidth + 'px', // Capture computed if style not set
+            height: ta.style.height || ta.offsetHeight + 'px' // Capture computed if style not set
+        };
+        // console.log('   • Textarea found, styles captured:', savedStyles);
+    }
+    return ta;
+  }
+
+  // 5) Inserta el botón toggle (una sola vez por modal)
+  function injectToggle(modal) {
+    // Check if the toggle already exists for this specific modal instance
+    if (modal.querySelector('#dbViewToggle')) {
+        // console.log('   • Toggle already exists for this modal.');
+        return; // Already injected for this modal
+    }
+    // Mark the modal to prevent re-injection attempts by the observer
+    // Note: This simple property might not persist if the modal element is replaced entirely.
+    // A more robust check might involve querying for the button ID again.
+    // modal._hasToggle = true; // Original check - might be less reliable if modal DOM changes significantly
+    console.log('– injectToggle');
+
+    const titleBar = modal.querySelector('.form_header .form_title_top');
+    if (!titleBar) {
+        console.warn('   ⚠️ Title bar not found for toggle injection.');
+        return;
+    }
+
+    const btn = document.createElement('button');
+    btn.id = 'dbViewToggle';
+    // Set initial state based on dbViewEnabled (useful if state persists somehow)
+    btn.innerText = `DB View: ${dbViewEnabled ? 'ON' : 'OFF'}`;
+    btn.style.marginLeft = '10px';
+    btn.style.padding = '2px 6px';
+    btn.style.cursor = 'pointer';
+    btn.style.border = '1px solid #ccc';
+    btn.style.background = '#eee';
+    btn.title = 'Toggle between raw text and formatted DB table view';
+
+    btn.addEventListener('click', ()=> {
+      // Find the specific modal and container related to *this* button click
+      const currentModal = btn.closest('#popup_on_popup_content_DocumentDialogContents');
+      if (!currentModal) {
+          console.error('   ❌ Could not find parent modal for toggle button.');
+          return;
+      }
+      const container = currentModal.querySelector('.documentViewer');
+      if (!container) {
+          console.error('   ❌ Could not find .documentViewer container in modal.');
+          return;
+      }
+
+      // Toggle the state *before* acting on it
+      dbViewEnabled = !dbViewEnabled;
+      console.log('   • dbViewEnabled toggled to =', dbViewEnabled);
+
+      if (dbViewEnabled) {
+        // --- Turning ON ---
+        const currentTextArea = findVisibleTextarea(currentModal);
+        if (currentTextArea) {
+          // *** Crucial Fix: Capture the *current* value just before replacing ***
+          originalRaw = currentTextArea.value;
+          console.log('   • originalRaw captured before rendering table.');
+
+          if (isDbDoc(originalRaw)) {
+            renderDbTable(originalRaw, container);
+          } else {
+            // Optional: Provide feedback if it's not a DB doc
+            console.log('   • Document is not in DB format. Keeping raw view.');
+            // If not DB format, toggle back off immediately? Or just leave raw view?
+            // For now, let's toggle back off as the view didn't change to table
+            dbViewEnabled = false; // Revert state as we didn't switch to table
+            alert("The document content doesn't appear to be in the expected DB format (|#|, |@|).");
+          }
+        } else {
+          console.warn('   ⚠️ Textarea not found when trying to turn ON DB View.');
+          // If no textarea, we can't proceed, so revert state
+          dbViewEnabled = false; // Revert state
+        }
+      } else {
+        // --- Turning OFF ---
+        // Restore should use the 'originalRaw' captured when turning ON
+        restoreTextarea(container);
+      }
+
+      // Update button text *after* logic is complete
+      btn.innerText = `DB View: ${dbViewEnabled ? 'ON' : 'OFF'}`;
+      btn.style.background = dbViewEnabled ? '#d4edda' : '#eee'; // Visual feedback
+    });
+
+    titleBar.appendChild(btn);
+    console.log('   • Toggle inyectado');
+  }
+
+  // 6) Observador para detectar modal y textarea
+  const observer = new MutationObserver((mutationsList, observer) => {
+      // Optimization: Check only added nodes for the modal ID
+      for (const mutation of mutationsList) {
+          if (mutation.type === 'childList' && mutation.addedNodes.length > 0) {
+              for (const node of mutation.addedNodes) {
+                  // Check if the added node itself is the modal or contains it
+                  if (node.nodeType === Node.ELEMENT_NODE) {
+                      let modal = null;
+                      if (node.id === 'popup_on_popup_content_DocumentDialogContents') {
+                          modal = node;
+                      } else if (node.querySelector) { // Check if querySelector is available
+                          modal = node.querySelector('#popup_on_popup_content_DocumentDialogContents');
+                      }
+
+                      if (modal) {
+                          console.log('   • Modal detected by observer:', modal.id);
+                          // Use requestAnimationFrame to ensure modal is fully rendered
+                          requestAnimationFrame(() => {
+                              injectToggle(modal);
+                              // Initial setup if needed (e.g., if dbViewEnabled was persisted)
+                              // Generally, let the user click the toggle first.
+                              // The original observer logic here might cause issues if the
+                              // textarea isn't ready immediately.
+                              // --- Original Observer Logic (potentially problematic) ---
+                              // const ta = findVisibleTextarea(modal); // Use updated function name
+                              // if (dbViewEnabled && ta) {
+                              //     const container = modal.querySelector('.documentViewer');
+                              //     if (container && isDbDoc(ta.value)) {
+                              //         originalRaw = ta.value; // Capture before render
+                              //         renderDbTable(ta.value, container);
+                              //     }
+                              // }
+                              // --- End Original ---
+                          });
+                          // Optimization: If we found the modal, maybe we don't need to check other added nodes in this mutation batch?
+                          // return; // Or break outer loop if only one modal expected at a time
+                      }
+                  }
+              }
+          }
+      }
+
+      // Fallback: Original broader check (less efficient)
+      // const modal = document.querySelector('#popup_on_popup_content_DocumentDialogContents');
+      // if (!modal) return;
+      // injectToggle(modal);
+      // // ... rest of original observer logic ...
+  });
+
+
+  console.log('   • Starting MutationObserver');
+  observer.observe(document.body, { childList: true, subtree: true });
+
+})();

--- a/src/library/boomiapp/documentViewer.js
+++ b/src/library/boomiapp/documentViewer.js
@@ -3,12 +3,12 @@
 // Añade un toggle “DB View” y un botón “🗖” de maximize en el modal de Document Viewer.
 // “DB View” carga Grid.js y muestra la tabla; “🗖” amplía/reduce el modal con efecto smooth.
 
-(function(){
+(function () {
   console.log('⚙️ documentViewer.js cargado');
 
   let dbViewEnabled = false;
-  let originalRaw    = null;
-  let savedStyles    = {};
+  let originalRaw = null;
+  let savedStyles = {};
 
   /** Inyecta estilos CSS para maximize y adaptación de la tabla */
   const style = document.createElement('style');
@@ -46,14 +46,14 @@
       if (!document.querySelector('link[data-gridjs]')) {
         const link = document.createElement('link');
         link.dataset.gridjs = '1';
-        link.rel  = 'stylesheet';
+        link.rel = 'stylesheet';
         link.href = 'https://unpkg.com/gridjs/dist/theme/mermaid.min.css';
         document.head.appendChild(link);
       }
       if (window.gridjs) return resolve();
       const script = document.createElement('script');
-      script.src    = 'https://unpkg.com/gridjs/dist/gridjs.umd.js';
-      script.onload  = () => resolve();
+      script.src = 'https://unpkg.com/gridjs/dist/gridjs.umd.js';
+      script.onload = () => resolve();
       script.onerror = () => reject(new Error('No se pudo cargar Grid.js'));
       document.head.appendChild(script);
     });
@@ -65,11 +65,11 @@
     const mount = document.createElement('div');
     container.appendChild(mount);
     new gridjs.Grid({
-      columns:    headers,
-      data:       dataRows,
-      search:     true,
-      sort:       true,
-      pagination: { enabled: true, limit: 10 },
+      columns: headers,
+      data: dataRows,
+      search: true,
+      sort: true,
+      pagination: { enabled: true, limit: 20 },
       style: { table: { 'white-space': 'nowrap' } }
     }).render(mount);
   }
@@ -79,10 +79,10 @@
     container.innerHTML = '';
     const ta = document.createElement('textarea');
     ta.className = 'gwt-TextArea';
-    ta.style.width  = savedStyles.width  || '620px';
+    ta.style.width = savedStyles.width || '620px';
     ta.style.height = savedStyles.height || '442px';
-    ta.readOnly     = true;
-    ta.value        = originalRaw || '';
+    ta.readOnly = true;
+    ta.value = originalRaw || '';
     container.appendChild(ta);
     console.log('   • textarea restaurado');
   }
@@ -90,10 +90,10 @@
   /** Encuentra el textarea visible y captura sus estilos */
   function findTextarea(modal) {
     const ta = Array.from(modal.querySelectorAll('textarea.gwt-TextArea'))
-                   .find(el => el.offsetParent !== null);
+      .find(el => el.offsetParent !== null);
     if (ta) {
       savedStyles = {
-        width:  ta.style.width  || ta.offsetWidth + 'px',
+        width: ta.style.width || ta.offsetWidth + 'px',
         height: ta.style.height || ta.offsetHeight + 'px'
       };
     }
@@ -112,10 +112,10 @@
 
     // --- Botón DB View ---
     const btn = document.createElement('button');
-    btn.id         = 'dbViewToggle';
-    btn.innerText  = `DB View: ${dbViewEnabled ? 'ON' : 'OFF'}`;
+    btn.id = 'dbViewToggle';
+    btn.innerText = `DB View: ${dbViewEnabled ? 'ON' : 'OFF'}`;
     btn.style.cssText = 'margin-left:8px;padding:2px 6px;cursor:pointer;border:1px solid #ccc;background:#eee;';
-    btn.title      = 'Toggle raw ↔ table view';
+    btn.title = 'Toggle raw ↔ table view';
     btn.addEventListener('click', async () => {
       const container = modal.querySelector('.documentViewer');
       dbViewEnabled = !dbViewEnabled;
@@ -127,19 +127,27 @@
         originalRaw = ta.value;
         // Limpieza y split
         let body = originalRaw.replace(/^DBSTART\|[\s\S]*?\|@?\|/, '')
-                              .replace(/\|@?\|DBEND\|[\s\S]*$/, '')
-                              .replace(/^BEGIN\|\d+\|@\|OUT_START\|\d+\|@\|/, '');
-        const segments = body.split('|#|').map(s=>s.trim())
-                             .filter(s=>s && !/^OUT_END/.test(s) && !/^END/.test(s));
-        const rows = segments.map(seg=>seg.split('|^|'));
-        const colCount = Math.max(...rows.map(r=>r.length));
-        rows.forEach(r=>{ while(r.length<colCount) r.push(''); });
-        const headers = Array.from({length:colCount},(_,i)=>`Column${i+1}`);
+          .replace(/\|@?\|DBEND\|[\s\S]*$/, '')
+          .replace(/^BEGIN\|\d+\|@\|OUT_START\|\d+\|@\|/, '');
+        let segments = body
+          .split('|#|')
+          .map(s => s.trim())
+          .filter(s => s && !/^OUT_END/.test(s) && !/^END/.test(s));
+
+        // Si el raw está truncado (no contiene DBEND), descartamos el último segmento parcial
+        if (!originalRaw.includes('|DBEND|') && segments.length > 0) {
+          segments.pop();
+        }
+
+        const rows = segments.map(seg => seg.split('|^|'));
+        const colCount = Math.max(...rows.map(r => r.length));
+        rows.forEach(r => { while (r.length < colCount) r.push(''); });
+        const headers = Array.from({ length: colCount }, (_, i) => `Column${i + 1}`);
 
         try {
           await loadGridJsFromCDN();
           renderWithGrid(headers, rows, container);
-        } catch(err) {
+        } catch (err) {
           console.error(err);
           restoreTextarea(container);
           dbViewEnabled = false;
@@ -149,16 +157,16 @@
         restoreTextarea(container);
       }
 
-      btn.innerText      = `DB View: ${dbViewEnabled?'ON':'OFF'}`;
+      btn.innerText = `DB View: ${dbViewEnabled ? 'ON' : 'OFF'}`;
       btn.style.background = dbViewEnabled ? '#d4edda' : '#eee';
     });
 
     // --- Botón Maximize ---
     const maxBtn = document.createElement('button');
-    maxBtn.id        = 'dbViewMaximize';
+    maxBtn.id = 'dbViewMaximize';
     maxBtn.innerText = '🗖';
     maxBtn.style.cssText = 'margin-left:4px;padding:2px 6px;cursor:pointer;border:1px solid #ccc;background:#eee;';
-    maxBtn.title     = 'Maximize modal';
+    maxBtn.title = 'Maximize modal';
     maxBtn.addEventListener('click', () => {
       modal.classList.toggle('dbview-maximized');
     });

--- a/src/library/boomiapp/documentViewer.js
+++ b/src/library/boomiapp/documentViewer.js
@@ -1,268 +1,192 @@
 // documentViewer.js
 // -----------------
-// Inyecta un toggle en el modal de Document Viewer y, al activarlo, renderiza
-// los datos BD en una tabla; al desactivarlo, restaura el textarea original.
+// Añade un toggle “DB View” y un botón “🗖” de maximize en el modal de Document Viewer.
+// “DB View” carga Grid.js y muestra la tabla; “🗖” amplía/reduce el modal con efecto smooth.
 
 (function(){
   console.log('⚙️ documentViewer.js cargado');
 
   let dbViewEnabled = false;
-  let originalRaw = null; // Store the raw text just before showing the table
-  let savedStyles = {};   // Store original textarea styles
+  let originalRaw    = null;
+  let savedStyles    = {};
 
-  // 1) Detecta si un raw corresponde a BD (delimitadores '|#|' y '|@|')
-  const isDbDoc = raw => raw && raw.includes('|#|') && raw.includes('|@|'); // Added null check for safety
+  /** Inyecta estilos CSS para maximize y adaptación de la tabla */
+  const style = document.createElement('style');
+  style.textContent = `
+    /* Modal maximizado */
+    #popup_on_popup_content_DocumentDialogContents.dbview-maximized {
+      width: 90vw !important;
+      height: 90vh !important;
+      left: 5vw !important;
+      top: 5vh !important;
+      transition: all 0.3s ease-in-out;
+    }
+    /* Asegura que el contenido fluya dentro */
+    #popup_on_popup_content_DocumentDialogContents.dbview-maximized .documentViewer {
+      width: 100% !important;
+      height: calc(100% - 80px) !important; /* deja espacio para cabecera/botones */
+      overflow: hidden;
+    }
+    /* Wrapper scrollable ocupa todo el espacio disponible */
+    #popup_on_popup_content_DocumentDialogContents .documentViewer > div {
+      width: 100% !important;
+      height: 100% !important;
+    }
+    /* Ajuste Grid.js al 100% */
+    .gridjs {
+      width: 100% !important;
+      height: 100% !important;
+    }
+  `;
+  document.head.appendChild(style);
 
-  // 2) Parsea raw y construye tabla
-  function renderDbTable(raw, container) {
-    // 1) Quita envoltorios DBSTART…DBEND
-    let body = raw;
-    if (/^DBSTART\|/.test(body)) {
-      body = body
-        .replace(/^DBSTART\|[\s\S]*?\|@?\|/, '')
-        .replace(/\|@?\|DBEND\|[\s\S]*$/, '');
-    }
-  
-    // 2) Elimina la cabecera BEGIN…OUT_START sobrante
-    //    (p. ej. "BEGIN|2|@|OUT_START|3|@|")
-    body = body.replace(/^BEGIN\|\d+\|@\|OUT_START\|\d+\|@\|/, '');
-  
-    // 3) Divide en segmentos con "|#|" y filtra vacíos/OUT_END/END
-    const segments = body
-      .split('|#|')
-      .map(s => s.trim())
-      .filter(s => s && !/^OUT_END/.test(s) && !/^END/.test(s));
-  
-    // 4) Convierte cada segmento en array de campos usando "|^|"
-    const rows = segments.map(seg => seg.split('|^|'));
-  
-    if (!rows.length) {
-      container.innerHTML = '<p style="padding:10px;color:#888;">No hay datos.</p>';
-      return;
-    }
-  
-    // 5) Calcula máximo de columnas y normaliza
-    const colCount = Math.max(...rows.map(r => r.length));
-    rows.forEach(r => { while (r.length < colCount) r.push(''); });
-  
-    // 6) Cabeceras genéricas
-    const headers = Array.from({ length: colCount }, (_, i) => `Column${i+1}`);
-  
-    // 7) Wrapper scrollable
-    container.innerHTML = '';
-    const wrap = document.createElement('div');
-    wrap.style.overflowX = 'auto';
-    wrap.style.overflowY = 'auto';
-    wrap.style.maxHeight = '300px';
-    wrap.style.maxWidth  = '100%';
-    wrap.style.border    = '1px solid #ddd';
-  
-    // 8) Construye tabla
-    const table = document.createElement('table');
-    table.style.borderCollapse = 'collapse';
-    table.style.width          = 'max-content';
-    table.style.minWidth       = '100%';
-  
-    // Cabecera
-    const thead = table.appendChild(document.createElement('thead'));
-    const htr   = thead.appendChild(document.createElement('tr'));
-    headers.forEach(h => {
-      const th = htr.appendChild(document.createElement('th'));
-      th.innerText        = h;
-      th.style.padding    = '6px';
-      th.style.border     = '1px solid #ccc';
-      th.style.background = '#f0f0f0';
-      th.style.whiteSpace = 'nowrap';
+  /** Carga Grid.js (CSS + JS) desde CDN */
+  function loadGridJsFromCDN() {
+    return new Promise((resolve, reject) => {
+      if (!document.querySelector('link[data-gridjs]')) {
+        const link = document.createElement('link');
+        link.dataset.gridjs = '1';
+        link.rel  = 'stylesheet';
+        link.href = 'https://unpkg.com/gridjs/dist/theme/mermaid.min.css';
+        document.head.appendChild(link);
+      }
+      if (window.gridjs) return resolve();
+      const script = document.createElement('script');
+      script.src    = 'https://unpkg.com/gridjs/dist/gridjs.umd.js';
+      script.onload  = () => resolve();
+      script.onerror = () => reject(new Error('No se pudo cargar Grid.js'));
+      document.head.appendChild(script);
     });
-  
-    // Cuerpo
-    const tbody = table.appendChild(document.createElement('tbody'));
-    rows.forEach((row, idx) => {
-      const tr = tbody.appendChild(document.createElement('tr'));
-      row.forEach(cell => {
-        const td = tr.appendChild(document.createElement('td'));
-        td.innerText        = cell;
-        td.style.padding    = '4px';
-        td.style.border     = '1px solid #eee';
-        td.style.whiteSpace = 'nowrap';
-      });
-      if (idx % 2) tr.style.background = '#fafafa';
-    });
-  
-    wrap.appendChild(table);
-    container.appendChild(wrap);
   }
-  
 
-  // 3) Crea o recupera el textarea original para restaurar
-  function restoreTextarea(container) {
-    // Limpia container
+  /** Renderiza la tabla con Grid.js */
+  function renderWithGrid(headers, dataRows, container) {
     container.innerHTML = '';
-    // Crea nuevo textarea
+    const mount = document.createElement('div');
+    container.appendChild(mount);
+    new gridjs.Grid({
+      columns:    headers,
+      data:       dataRows,
+      search:     true,
+      sort:       true,
+      pagination: { enabled: true, limit: 10 },
+      style: { table: { 'white-space': 'nowrap' } }
+    }).render(mount);
+  }
+
+  /** Restaura el textarea original */
+  function restoreTextarea(container) {
+    container.innerHTML = '';
     const ta = document.createElement('textarea');
-    ta.className = 'gwt-TextArea'; // Use the original class
-    // Apply saved styles (ensure they were captured)
-    ta.style.width = savedStyles.width || '100%'; // Provide defaults
-    ta.style.height = savedStyles.height || '300px'; // Provide defaults
-    ta.readOnly = true; // Match original Boomi behavior (usually read-only)
-    ta.value = originalRaw || ''; // Use the captured raw value
+    ta.className = 'gwt-TextArea';
+    ta.style.width  = savedStyles.width  || '620px';
+    ta.style.height = savedStyles.height || '442px';
+    ta.readOnly     = true;
+    ta.value        = originalRaw || '';
     container.appendChild(ta);
     console.log('   • textarea restaurado');
   }
 
-  // 4) Obtiene el textarea visible y sus estilos
-  function findVisibleTextarea(modal) {
-    // Find the textarea that is currently visible (part of the DOM layout)
+  /** Encuentra el textarea visible y captura sus estilos */
+  function findTextarea(modal) {
     const ta = Array.from(modal.querySelectorAll('textarea.gwt-TextArea'))
-                    .find(el => el.offsetParent !== null);
+                   .find(el => el.offsetParent !== null);
     if (ta) {
-        // Capture styles *every time* we find it, in case they change
-        savedStyles = {
-            width: ta.style.width || ta.offsetWidth + 'px', // Capture computed if style not set
-            height: ta.style.height || ta.offsetHeight + 'px' // Capture computed if style not set
-        };
-        // console.log('   • Textarea found, styles captured:', savedStyles);
+      savedStyles = {
+        width:  ta.style.width  || ta.offsetWidth + 'px',
+        height: ta.style.height || ta.offsetHeight + 'px'
+      };
     }
     return ta;
   }
 
-  // 5) Inserta el botón toggle (una sola vez por modal)
+  /** Inyecta los botones DB View y Maximize */
   function injectToggle(modal) {
-    // Check if the toggle already exists for this specific modal instance
-    if (modal.querySelector('#dbViewToggle')) {
-        // console.log('   • Toggle already exists for this modal.');
-        return; // Already injected for this modal
-    }
-    // Mark the modal to prevent re-injection attempts by the observer
-    // Note: This simple property might not persist if the modal element is replaced entirely.
-    // A more robust check might involve querying for the button ID again.
-    // modal._hasToggle = true; // Original check - might be less reliable if modal DOM changes significantly
+    // Ya inyectado?
+    if (modal.querySelector('#dbViewToggle')) return;
     console.log('– injectToggle');
 
+    // Cabecera del modal
     const titleBar = modal.querySelector('.form_header .form_title_top');
-    if (!titleBar) {
-        console.warn('   ⚠️ Title bar not found for toggle injection.');
-        return;
-    }
+    if (!titleBar) return;
 
+    // --- Botón DB View ---
     const btn = document.createElement('button');
-    btn.id = 'dbViewToggle';
-    // Set initial state based on dbViewEnabled (useful if state persists somehow)
-    btn.innerText = `DB View: ${dbViewEnabled ? 'ON' : 'OFF'}`;
-    btn.style.marginLeft = '10px';
-    btn.style.padding = '2px 6px';
-    btn.style.cursor = 'pointer';
-    btn.style.border = '1px solid #ccc';
-    btn.style.background = '#eee';
-    btn.title = 'Toggle between raw text and formatted DB table view';
-
-    btn.addEventListener('click', ()=> {
-      // Find the specific modal and container related to *this* button click
-      const currentModal = btn.closest('#popup_on_popup_content_DocumentDialogContents');
-      if (!currentModal) {
-          console.error('   ❌ Could not find parent modal for toggle button.');
-          return;
-      }
-      const container = currentModal.querySelector('.documentViewer');
-      if (!container) {
-          console.error('   ❌ Could not find .documentViewer container in modal.');
-          return;
-      }
-
-      // Toggle the state *before* acting on it
+    btn.id         = 'dbViewToggle';
+    btn.innerText  = `DB View: ${dbViewEnabled ? 'ON' : 'OFF'}`;
+    btn.style.cssText = 'margin-left:8px;padding:2px 6px;cursor:pointer;border:1px solid #ccc;background:#eee;';
+    btn.title      = 'Toggle raw ↔ table view';
+    btn.addEventListener('click', async () => {
+      const container = modal.querySelector('.documentViewer');
       dbViewEnabled = !dbViewEnabled;
-      console.log('   • dbViewEnabled toggled to =', dbViewEnabled);
+      console.log('• dbViewEnabled =', dbViewEnabled);
 
       if (dbViewEnabled) {
-        // --- Turning ON ---
-        const currentTextArea = findVisibleTextarea(currentModal);
-        if (currentTextArea) {
-          // *** Crucial Fix: Capture the *current* value just before replacing ***
-          originalRaw = currentTextArea.value;
-          console.log('   • originalRaw captured before rendering table.');
+        const ta = findTextarea(modal);
+        if (!ta) { dbViewEnabled = false; return; }
+        originalRaw = ta.value;
+        // Limpieza y split
+        let body = originalRaw.replace(/^DBSTART\|[\s\S]*?\|@?\|/, '')
+                              .replace(/\|@?\|DBEND\|[\s\S]*$/, '')
+                              .replace(/^BEGIN\|\d+\|@\|OUT_START\|\d+\|@\|/, '');
+        const segments = body.split('|#|').map(s=>s.trim())
+                             .filter(s=>s && !/^OUT_END/.test(s) && !/^END/.test(s));
+        const rows = segments.map(seg=>seg.split('|^|'));
+        const colCount = Math.max(...rows.map(r=>r.length));
+        rows.forEach(r=>{ while(r.length<colCount) r.push(''); });
+        const headers = Array.from({length:colCount},(_,i)=>`Column${i+1}`);
 
-          if (isDbDoc(originalRaw)) {
-            renderDbTable(originalRaw, container);
-          } else {
-            // Optional: Provide feedback if it's not a DB doc
-            console.log('   • Document is not in DB format. Keeping raw view.');
-            // If not DB format, toggle back off immediately? Or just leave raw view?
-            // For now, let's toggle back off as the view didn't change to table
-            dbViewEnabled = false; // Revert state as we didn't switch to table
-            alert("The document content doesn't appear to be in the expected DB format (|#|, |@|).");
-          }
-        } else {
-          console.warn('   ⚠️ Textarea not found when trying to turn ON DB View.');
-          // If no textarea, we can't proceed, so revert state
-          dbViewEnabled = false; // Revert state
+        try {
+          await loadGridJsFromCDN();
+          renderWithGrid(headers, rows, container);
+        } catch(err) {
+          console.error(err);
+          restoreTextarea(container);
+          dbViewEnabled = false;
+          alert('Error cargando tabla interactiva.');
         }
       } else {
-        // --- Turning OFF ---
-        // Restore should use the 'originalRaw' captured when turning ON
         restoreTextarea(container);
       }
 
-      // Update button text *after* logic is complete
-      btn.innerText = `DB View: ${dbViewEnabled ? 'ON' : 'OFF'}`;
-      btn.style.background = dbViewEnabled ? '#d4edda' : '#eee'; // Visual feedback
+      btn.innerText      = `DB View: ${dbViewEnabled?'ON':'OFF'}`;
+      btn.style.background = dbViewEnabled ? '#d4edda' : '#eee';
     });
 
-    titleBar.appendChild(btn);
-    console.log('   • Toggle inyectado');
+    // --- Botón Maximize ---
+    const maxBtn = document.createElement('button');
+    maxBtn.id        = 'dbViewMaximize';
+    maxBtn.innerText = '🗖';
+    maxBtn.style.cssText = 'margin-left:4px;padding:2px 6px;cursor:pointer;border:1px solid #ccc;background:#eee;';
+    maxBtn.title     = 'Maximize modal';
+    maxBtn.addEventListener('click', () => {
+      modal.classList.toggle('dbview-maximized');
+    });
+
+    titleBar.append(btn, maxBtn);
+    console.log('   • Toggle & Maximize inyectados');
   }
 
-  // 6) Observador para detectar modal y textarea
-  const observer = new MutationObserver((mutationsList, observer) => {
-      // Optimization: Check only added nodes for the modal ID
-      for (const mutation of mutationsList) {
-          if (mutation.type === 'childList' && mutation.addedNodes.length > 0) {
-              for (const node of mutation.addedNodes) {
-                  // Check if the added node itself is the modal or contains it
-                  if (node.nodeType === Node.ELEMENT_NODE) {
-                      let modal = null;
-                      if (node.id === 'popup_on_popup_content_DocumentDialogContents') {
-                          modal = node;
-                      } else if (node.querySelector) { // Check if querySelector is available
-                          modal = node.querySelector('#popup_on_popup_content_DocumentDialogContents');
-                      }
-
-                      if (modal) {
-                          console.log('   • Modal detected by observer:', modal.id);
-                          // Use requestAnimationFrame to ensure modal is fully rendered
-                          requestAnimationFrame(() => {
-                              injectToggle(modal);
-                              // Initial setup if needed (e.g., if dbViewEnabled was persisted)
-                              // Generally, let the user click the toggle first.
-                              // The original observer logic here might cause issues if the
-                              // textarea isn't ready immediately.
-                              // --- Original Observer Logic (potentially problematic) ---
-                              // const ta = findVisibleTextarea(modal); // Use updated function name
-                              // if (dbViewEnabled && ta) {
-                              //     const container = modal.querySelector('.documentViewer');
-                              //     if (container && isDbDoc(ta.value)) {
-                              //         originalRaw = ta.value; // Capture before render
-                              //         renderDbTable(ta.value, container);
-                              //     }
-                              // }
-                              // --- End Original ---
-                          });
-                          // Optimization: If we found the modal, maybe we don't need to check other added nodes in this mutation batch?
-                          // return; // Or break outer loop if only one modal expected at a time
-                      }
-                  }
-              }
+  /** Observa inserciones para detectar el modal */
+  const observer = new MutationObserver((mutations) => {
+    for (const m of mutations) {
+      for (const node of m.addedNodes) {
+        if (node.nodeType === 1) {
+          let modal = null;
+          if (node.id === 'popup_on_popup_content_DocumentDialogContents') {
+            modal = node;
+          } else if (node.querySelector) {
+            modal = node.querySelector('#popup_on_popup_content_DocumentDialogContents');
           }
+          if (modal) {
+            console.log('• Modal detectado');
+            requestAnimationFrame(() => injectToggle(modal));
+          }
+        }
       }
-
-      // Fallback: Original broader check (less efficient)
-      // const modal = document.querySelector('#popup_on_popup_content_DocumentDialogContents');
-      // if (!modal) return;
-      // injectToggle(modal);
-      // // ... rest of original observer logic ...
+    }
   });
 
-
-  console.log('   • Starting MutationObserver');
+  console.log('• Iniciando MutationObserver');
   observer.observe(document.body, { childList: true, subtree: true });
-
 })();

--- a/src/library/boomiapp/documentViewer.js
+++ b/src/library/boomiapp/documentViewer.js
@@ -1,19 +1,48 @@
 // documentViewer.js
 // -----------------
-// Añade un toggle “DB View” y un botón “🗖” de maximize en el modal de Document Viewer.
-// “DB View” carga Grid.js y muestra la tabla; “🗖” amplía/reduce el modal con efecto smooth.
+// Adds a “See table” toggle and a “🗖” maximize button in the top right corner
+// of the Document Viewer modal. “See table” loads Grid.js to display the raw DB data as a table.
+// The “🗖” button maximizes/restores the modal with functional scroll in both states.
 
-(function () {
-  console.log('⚙️ documentViewer.js cargado');
+(function(){
+  console.log('⚙️ documentViewer.js loaded');
 
-  let dbViewEnabled = false;
-  let originalRaw = null;
-  let savedStyles = {};
+  let originalRaw = null, savedStyles = {};
 
-  /** Inyecta estilos CSS para maximize y adaptación de la tabla */
+  // 1) Inject updated CSS styles
   const style = document.createElement('style');
   style.textContent = `
-    /* Modal maximizado */
+    /* Top-right controls container */
+    #popup_on_popup_content_DocumentDialogContents .dbview-controls {
+      position: absolute;
+      top: 8px;
+      right: 12px;
+      display: flex;
+      gap: 8px;
+      z-index: 1000;
+    }
+    .dbview-toggle { display:flex; align-items:center; cursor:pointer; }
+    .dbview-toggle input { margin-right:4px; }
+
+    /* Force flex layout on .documentViewer to fill modal space */
+    #popup_on_popup_content_DocumentDialogContents .documentViewer {
+      display: flex !important;
+      flex-direction: column !important;
+      padding: 0 !important;
+    }
+    /* The first inner div should take all available space and be scrollable */
+    #popup_on_popup_content_DocumentDialogContents .documentViewer > div {
+      flex: 1 1 auto !important;
+      overflow: auto !important;
+    }
+    /* Ensure gridjs itself is scrollable if needed */
+    .gridjs-wrapper {
+      height: 100% !important;
+      width: 100% !important;
+      overflow: auto !important;
+    }
+
+    /* Modal in maximized mode */
     #popup_on_popup_content_DocumentDialogContents.dbview-maximized {
       width: 90vw !important;
       height: 90vh !important;
@@ -21,180 +50,147 @@
       top: 5vh !important;
       transition: all 0.3s ease-in-out;
     }
-    /* Asegura que el contenido fluya dentro */
+    /* Adjust viewer size when modal is maximized */
     #popup_on_popup_content_DocumentDialogContents.dbview-maximized .documentViewer {
       width: 100% !important;
-      height: calc(100% - 80px) !important; /* deja espacio para cabecera/botones */
-      overflow: hidden;
+      height: calc(100% - 40px) !important;
     }
-    /* Wrapper scrollable ocupa todo el espacio disponible */
-    #popup_on_popup_content_DocumentDialogContents .documentViewer > div {
+    /* Override inline size styles that Boomi might inject */
+    #popup_on_popup_content_DocumentDialogContents .documentViewer.secondary {
       width: 100% !important;
       height: 100% !important;
     }
-    /* Ajuste Grid.js al 100% */
-    .gridjs {
+    #popup_on_popup_content_DocumentDialogContents.dbview-maximized .documentViewer.secondary {
       width: 100% !important;
-      height: 100% !important;
+      height: calc(100% - 40px) !important;
     }
   `;
   document.head.appendChild(style);
 
-  /** Carga Grid.js (CSS + JS) desde CDN */
-  function loadGridJsFromCDN() {
+  // 2) Load Grid.js (JS + CSS) from CDN
+  function loadGridJs() {
     return new Promise((resolve, reject) => {
       if (!document.querySelector('link[data-gridjs]')) {
-        const link = document.createElement('link');
-        link.dataset.gridjs = '1';
-        link.rel = 'stylesheet';
-        link.href = 'https://unpkg.com/gridjs/dist/theme/mermaid.min.css';
-        document.head.appendChild(link);
+        const l = document.createElement('link');
+        l.dataset.gridjs = '1';
+        l.rel = 'stylesheet';
+        l.href = 'https://unpkg.com/gridjs/dist/theme/mermaid.min.css';
+        document.head.appendChild(l);
       }
       if (window.gridjs) return resolve();
-      const script = document.createElement('script');
-      script.src = 'https://unpkg.com/gridjs/dist/gridjs.umd.js';
-      script.onload = () => resolve();
-      script.onerror = () => reject(new Error('No se pudo cargar Grid.js'));
-      document.head.appendChild(script);
+      const s = document.createElement('script');
+      s.src = 'https://unpkg.com/gridjs/dist/gridjs.umd.js';
+      s.onload  = () => resolve();
+      s.onerror = () => reject('Error loading Grid.js');
+      document.head.appendChild(s);
     });
   }
 
-  /** Renderiza la tabla con Grid.js */
-  function renderWithGrid(headers, dataRows, container) {
+  // 3) Render the table using Grid.js
+  function renderGrid(headers, rows, container) {
     container.innerHTML = '';
     const mount = document.createElement('div');
     container.appendChild(mount);
     new gridjs.Grid({
       columns: headers,
-      data: dataRows,
-      search: true,
-      sort: true,
-      pagination: { enabled: true, limit: 20 },
-      style: { table: { 'white-space': 'nowrap' } }
+      data:    rows,
+      search:  true,
+      sort:    true,
+      resizable: true,
+      pagination: { enabled: true, limit: 20 }
     }).render(mount);
   }
 
-  /** Restaura el textarea original */
+  // 4) Restore the original textarea view
   function restoreTextarea(container) {
     container.innerHTML = '';
     const ta = document.createElement('textarea');
     ta.className = 'gwt-TextArea';
-    ta.style.width = savedStyles.width || '620px';
+    ta.style.width  = savedStyles.width  || '620px';
     ta.style.height = savedStyles.height || '442px';
-    ta.readOnly = true;
-    ta.value = originalRaw || '';
+    ta.readOnly     = true;
+    ta.value        = originalRaw || '';
     container.appendChild(ta);
-    console.log('   • textarea restaurado');
   }
 
-  /** Encuentra el textarea visible y captura sus estilos */
+  // 5) Find the currently visible textarea and save its dimensions
   function findTextarea(modal) {
     const ta = Array.from(modal.querySelectorAll('textarea.gwt-TextArea'))
-      .find(el => el.offsetParent !== null);
-    if (ta) {
-      savedStyles = {
-        width: ta.style.width || ta.offsetWidth + 'px',
-        height: ta.style.height || ta.offsetHeight + 'px'
-      };
-    }
+                    .find(el => el.offsetParent !== null);
+    if (ta) savedStyles = {
+      width:  ta.style.width  || `${ta.offsetWidth}px`,
+      height: ta.style.height || `${ta.offsetHeight}px`
+    };
     return ta;
   }
 
-  /** Inyecta los botones DB View y Maximize */
-  function injectToggle(modal) {
-    // Ya inyectado?
-    if (modal.querySelector('#dbViewToggle')) return;
-    console.log('– injectToggle');
+  // 6) Check if content starts with DBSTART
+  function isDb(raw) {
+    return raw?.startsWith('DBSTART|');
+  }
 
-    // Cabecera del modal
-    const titleBar = modal.querySelector('.form_header .form_title_top');
-    if (!titleBar) return;
+  // 7) Inject top-right controls (toggle + maximize button)
+  function injectControls(modal) {
+    if (modal.querySelector('.dbview-controls')) return;
 
-    // --- Botón DB View ---
-    const btn = document.createElement('button');
-    btn.id = 'dbViewToggle';
-    btn.innerText = `DB View: ${dbViewEnabled ? 'ON' : 'OFF'}`;
-    btn.style.cssText = 'margin-left:8px;padding:2px 6px;cursor:pointer;border:1px solid #ccc;background:#eee;';
-    btn.title = 'Toggle raw ↔ table view';
-    btn.addEventListener('click', async () => {
+    const ta = findTextarea(modal);
+    if (!ta || !isDb(ta.value)) return;
+
+    originalRaw = ta.value;
+
+    const ctrls = document.createElement('div');
+    ctrls.className = 'dbview-controls';
+
+    // Toggle: See table
+    const lbl = document.createElement('label');
+    lbl.className = 'dbview-toggle';
+    const chk = document.createElement('input');
+    chk.type = 'checkbox';
+    lbl.append(chk, document.createTextNode('See table'));
+    chk.addEventListener('change', async () => {
       const container = modal.querySelector('.documentViewer');
-      dbViewEnabled = !dbViewEnabled;
-      console.log('• dbViewEnabled =', dbViewEnabled);
-
-      if (dbViewEnabled) {
-        const ta = findTextarea(modal);
-        if (!ta) { dbViewEnabled = false; return; }
-        originalRaw = ta.value;
-        // Limpieza y split
-        let body = originalRaw.replace(/^DBSTART\|[\s\S]*?\|@?\|/, '')
+      if (chk.checked) {
+        let body = originalRaw
+          .replace(/^DBSTART\|[\s\S]*?\|@?\|/, '')
           .replace(/\|@?\|DBEND\|[\s\S]*$/, '')
           .replace(/^BEGIN\|\d+\|@\|OUT_START\|\d+\|@\|/, '');
-        let segments = body
-          .split('|#|')
-          .map(s => s.trim())
-          .filter(s => s && !/^OUT_END/.test(s) && !/^END/.test(s));
-
-        // Si el raw está truncado (no contiene DBEND), descartamos el último segmento parcial
-        if (!originalRaw.includes('|DBEND|') && segments.length > 0) {
-          segments.pop();
-        }
-
-        const rows = segments.map(seg => seg.split('|^|'));
-        const colCount = Math.max(...rows.map(r => r.length));
-        rows.forEach(r => { while (r.length < colCount) r.push(''); });
-        const headers = Array.from({ length: colCount }, (_, i) => `Column${i + 1}`);
-
+        let segs = body.split('|#|').map(s => s.trim())
+                       .filter(s => s && !/^OUT_END/.test(s) && !/^END/.test(s));
+        if (!originalRaw.includes('|DBEND|') && segs.length) segs.pop();
+        const rows = segs.map(s => s.split('|^|'));
+        const cols = Math.max(...rows.map(r => r.length));
+        rows.forEach(r => { while (r.length < cols) r.push(''); });
+        const headers = Array.from({length: cols}, (_, i) => `Column${i + 1}`);
         try {
-          await loadGridJsFromCDN();
-          renderWithGrid(headers, rows, container);
-        } catch (err) {
-          console.error(err);
+          await loadGridJs();
+          renderGrid(headers, rows, container);
+        } catch (e) {
+          console.error(e);
+          chk.checked = false;
           restoreTextarea(container);
-          dbViewEnabled = false;
-          alert('Error cargando tabla interactiva.');
         }
       } else {
-        restoreTextarea(container);
+        restoreTextarea(modal.querySelector('.documentViewer'));
       }
-
-      btn.innerText = `DB View: ${dbViewEnabled ? 'ON' : 'OFF'}`;
-      btn.style.background = dbViewEnabled ? '#d4edda' : '#eee';
     });
 
-    // --- Botón Maximize ---
-    const maxBtn = document.createElement('button');
-    maxBtn.id = 'dbViewMaximize';
-    maxBtn.innerText = '🗖';
-    maxBtn.style.cssText = 'margin-left:4px;padding:2px 6px;cursor:pointer;border:1px solid #ccc;background:#eee;';
-    maxBtn.title = 'Maximize modal';
-    maxBtn.addEventListener('click', () => {
+    // Maximize button
+    const max = document.createElement('button');
+    max.textContent = '🗖';
+    max.title = 'Maximize modal';
+    max.style.cursor = 'pointer';
+    max.addEventListener('click', () => {
       modal.classList.toggle('dbview-maximized');
     });
 
-    titleBar.append(btn, maxBtn);
-    console.log('   • Toggle & Maximize inyectados');
+    ctrls.append(lbl, max);
+    modal.appendChild(ctrls);
   }
 
-  /** Observa inserciones para detectar el modal */
-  const observer = new MutationObserver((mutations) => {
-    for (const m of mutations) {
-      for (const node of m.addedNodes) {
-        if (node.nodeType === 1) {
-          let modal = null;
-          if (node.id === 'popup_on_popup_content_DocumentDialogContents') {
-            modal = node;
-          } else if (node.querySelector) {
-            modal = node.querySelector('#popup_on_popup_content_DocumentDialogContents');
-          }
-          if (modal) {
-            console.log('• Modal detectado');
-            requestAnimationFrame(() => injectToggle(modal));
-          }
-        }
-      }
-    }
-  });
+  // 8) Polling to detect the appearance of the modal
+  setInterval(() => {
+    const modal = document.querySelector('#popup_on_popup_content_DocumentDialogContents');
+    if (modal) injectControls(modal);
+  }, 300);
 
-  console.log('• Iniciando MutationObserver');
-  observer.observe(document.body, { childList: true, subtree: true });
 })();

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -85,6 +85,7 @@
                 "library/boomiapp/connectionOperations.js",
                 "library/boomiapp/versionNotification.js",
                 "library/boomiapp/modalButtons.js",
+                "library/boomiapp/documentViewer.js",
                 "library/inject/rasterizeHTML.min.js",
                 "library/inject/showdown.min.js",
                 "library/inject/codeflask.min.js"


### PR DESCRIPTION
Hello,

This PR adds a toggle ("See table") and a maximize button ("🗖") to the Boomi Document Viewer modal. If the document is in DBSTART format, the toggle allows switching between the raw text and a Grid.js-rendered interactive table. The maximize button expands the modal for better data visibility.

When viewing raw database documents, the default plain-text format is unreadable due to lack of structure. This improvement allows users to visualize and interact with the data in a much more accessible and user-friendly table layout. It also supports long data sets with scroll and pagination, and gracefully restores the original view when disabled. Based on this [issue](https://github.com/matt-flaig/Boomi-Platform-Extension/issues/34).

**Behaviour:** 
- The code watches for the modal via setInterval.
- When detected, it checks if the document starts with DBSTART| to determine if table rendering is supported.
- If so, it injects a checkbox ("See table") and a maximize button ("🗖") into the modal.
- The toggle loads Grid.js from CDN on demand and renders the parsed data into columns and rows.
- The maximize button enlarges the modal with smooth transitions and adaptive scroll behavior.
- Fallbacks are in place if Grid.js fails to 

**Progress**
- [x] Works with real DBSTART documents
- [x] Fallbacks to textarea when disabled
- [x] Handles incomplete data gracefully
- [x] No impact on documents that are not DB formatted
- [ ] Responsive scroll behavior in both modal states
- [X] Pagination for large documents 

I hope you like it.
![Screenshot 2025-04-25 094359](https://github.com/user-attachments/assets/661be87f-b940-49dd-926a-3ffb05b72772)
![Screenshot 2025-04-25 094513](https://github.com/user-attachments/assets/b62c543f-3be9-4f28-a592-4a02ea7f4ab4)
![Screenshot 2025-04-25 094534](https://github.com/user-attachments/assets/69be987b-4680-4ad7-86b3-8a88617ca0f1)
